### PR TITLE
revert accessibility changes for hero

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -54,7 +54,9 @@ p {
     height: 800px;
     width: 100%;
     margin-bottom: 25px;
-    overflow: hidden;
+    background-image: url("../images/digital-marketing-meeting.jpg");
+    background-size: cover;
+    background-position: center;
 }
 
 .float-left {

--- a/index.html
+++ b/index.html
@@ -24,9 +24,7 @@
             </ul>
         </nav>
     </header>
-    <div id="hero">
-        <img src="./assets/images/digital-marketing-meeting.jpg" width="100%" alt="group of people in a digital marketing meeting"> 
-    </div>
+    <div id="hero"></div>
     <main>
         <section id="search-engine-optimization">
             <img src="./assets/images/search-engine-optimization.jpg" class="float-left" alt="desktop photo of a diary with SEO in the middle and some illustrations surrounding it, a coffe cup, laptop, pens and a magnifying glass" />


### PR DESCRIPTION
Per WCAG 2.0 (Web Content Accessibility Guidelines) states "When an image is used for decoration, spacing or other purpose that is not part of the meaningful content in the page then the image has no meaning and should be ignored by assistive technologies."

Hero does not need to have an alt tag as it is not part of the meaningful content of the page and is purely decorative.